### PR TITLE
HdAgent script finds token irrespective of script location

### DIFF
--- a/hdagent.sh
+++ b/hdagent.sh
@@ -21,8 +21,8 @@ if [ "$UID" -eq 0 ]; then
   exit 1
 fi
 
-BASE_DIR=$(pwd)
-CONFIG_FILE=conf/config.json
+BASE_DIR=$HOME/fivetran
+CONFIG_FILE=$BASE_DIR/conf/config.json
 AGENT_IMAGE="us-docker.pkg.dev/prod-eng-fivetran-ldp/public-docker-us/ldp-agent:production"
 CONTAINER_NETWORK="fivetran_ldp"
 TOKEN=""
@@ -154,7 +154,7 @@ start_agent() {
     -v $BASE_DIR/conf:/conf \
     -v $BASE_DIR/logs:/logs \
     -v $SOCKET:$INTERNAL_SOCKET \
-    $AGENT_IMAGE -f /conf/config.json
+    $AGENT_IMAGE -f $CONFIG_FILE
 
     sleep 3
     $RUN_CMD ps -f name="^/controller" -f label=fivetran=ldp --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -21,7 +21,8 @@ if [ "$UID" -eq 0 ]; then
   exit 1
 fi
 
-BASE_DIR=$HOME/fivetran
+mapfile -t SEARCH_DIR < <(find / -type d -name "fivetran" 2>/dev/null)
+BASE_DIR="${SEARCH_DIR[0]}"
 CONFIG_FILE=$BASE_DIR/conf/config.json
 AGENT_IMAGE="us-docker.pkg.dev/prod-eng-fivetran-ldp/public-docker-us/ldp-agent:production"
 CONTAINER_NETWORK="fivetran_ldp"


### PR DESCRIPTION
Based on the [installation instructions](https://fivetran.com/docs/deployment-models/hybrid-deployment/setup-guide-docker-and-podman), it looks like the fivetran folder will always live in $HOME. Using $pwd in ./hdagent.sh will make it so that if the hdagent script is placed elsewhere, then the script won't run. 