### PR TITLE
Modify config map to allow annotations in k8s jobs and helm config

### DIFF
--- a/agent/templates/configmap.yaml
+++ b/agent/templates/configmap.yaml
@@ -7,6 +7,10 @@ metadata:
     app.kubernetes.io/name: hd-agent-config
     {{- include "hd.labels" . | nindent 4 }}
 data:
-  {{- range $key, $value := .Values.config }}
+{{- range $key, $value := .Values.config }}
+  {{- if kindIs "map" $value }}
+  {{ $key }}: {{ $value | toJson | quote }}
+  {{- else }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+{{- end }}

--- a/agent/values.yaml
+++ b/agent/values.yaml
@@ -5,7 +5,6 @@ config:
   data_volume_pvc: 
   token:
   annotations: {}
-  service_account:  
 
 labels: {}
 node_selector: {}

--- a/agent/values.yaml
+++ b/agent/values.yaml
@@ -3,7 +3,9 @@ image_pull_policy: "Always"
 
 config:
   data_volume_pvc: 
-  token: 
+  token:
+  annotations: {}
+  service_account:  
 
 labels: {}
 node_selector: {}


### PR DESCRIPTION
This PR contains changes to the values.yaml and configmap so that kubernetes jobs can utilize annotations, which is needed for bucket support in cloud environments.