### PR TITLE
Improve hdagent.sh and update README to provide option to use systemd service for agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ After=network.target docker.service podman.service
 Requires=default.target
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=true
 WorkingDirectory=%h/fivetran
 ExecStart=%h/fivetran/hdagent.sh start
-Restart=on-failure
-RestartSec=10s
+ExecStop=%h/fivetran/hdagent.sh stop
 Environment=PATH=/usr/bin:/bin
 
 [Install]
@@ -114,6 +114,8 @@ podman logs controller
 ```
 sudo loginctl enable-linger $USER
 ```
+
+To make sure setting was applied run: `loginctl show-user $USER` and review `Linger` value.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,59 @@ Usage:
 ./hdagent.sh [-r docker|podman] start|stop|status
 ```
 
+### Step 3: Use systemd to manage agent (optional)
+
+This is optional and example of how you can configure a service to start the agent.
+
+To ensure the agent is restarted on system boot, you can make use of systemd.
+During the docker or podman run command, you can adjust `--restart "on-failure:3"` to `--restart "always"` and for most this will work fine.  But in podman this may not always work as intended.
+
+To ensure the agent is started as a service, you can do the following:
+
+> Note: the steps below is for podman using rootless.  The systemd will run under the user, not root. 
+1. Stop agent first: `./hdagent.sh stop`
+2. Create a local user systemd unit file: `~/.config/systemd/user/hdagent.service` and add the following:
+
+```
+[Unit]
+Description=Fivetran Hybrid Deployment Agent
+After=network.target docker.service podman.service
+Requires=default.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/fivetran
+ExecStart=%h/fivetran/hdagent.sh start
+Restart=on-failure
+RestartSec=10s
+Environment=PATH=/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+```
+
+3.  Reload and enable the service
+
+```
+systemctl --user daemon-reload
+systemctl --user start hdagent.service
+systemctl --user status hdagent.service
+```
+
+You can now review if the agent is running with: 
+```
+podman ps -a
+podman logs controller
+```
+
+4.  Enable lingering to make sure the services are started at boot time
+
+> Note: $USER is the unix user that will run the agent.
+
+```
+sudo loginctl enable-linger $USER
+```
+
 </details>
 
 

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -163,9 +163,7 @@ start_agent() {
         $AGENT_IMAGE -f /conf/config.json
 
     sleep 3
-    $RUN_CMD 
-     po
-     d--format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    $RUN_CMD ps -f name="^/?controller" -f label=fivetran=ldp --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
 }
 
 restart_existing_agent_if_needed() {

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -8,7 +8,7 @@
 #  - Docker is the default runtime, if using podman use "-r podman"
 #  - If no runtime specified, detect if docker or podman available
 #
-#  For more information: 
+#  For more information:
 #     https://fivetran.com/docs/core-concepts/architecture/hybrid-deployment
 #
 #  usage: ./hdagent.sh [-r docker|podman] start|stop|status
@@ -46,10 +46,10 @@ get_token_from_config() {
 }
 
 set_environment() {
-    # Set the environment depending on docker or podman 
+    # Set the environment depending on docker or podman
 
     RUN_CMD="$1"
-    
+
     # ensure command is available and in path
     if ! command -v $RUN_CMD &> /dev/null
     then
@@ -66,7 +66,7 @@ set_environment() {
         else
             SOCKET="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
         fi
-    else 
+    else
         # docker is used
         CONTAINER_ENV_TYPE="docker"
         INTERNAL_SOCKET="/var/run/docker.sock"
@@ -131,6 +131,13 @@ stop_agent() {
 }
 
 start_agent() {
+    # Remove existing stopped "controller" container if it exists
+    EXISTING=$($RUN_CMD ps -a -q -f name="^/?controller$" -f label=fivetran=ldp)
+    if [[ -n "$EXISTING" ]]; then
+        echo "Removing old stopped container named 'controller'"
+        $RUN_CMD rm "$EXISTING"
+    fi
+
     # create the default network if it does not exist
     set +e
     $RUN_CMD network create --driver bridge $CONTAINER_NETWORK > /dev/null 2>&1
@@ -149,7 +156,6 @@ start_agent() {
         --name controller \
         --network $CONTAINER_NETWORK \
         --env HOST_USER_HOME_DIR=$HOME \
-        --env TOKEN=$TOKEN \
         --env CONTAINER_ENV_TYPE=$CONTAINER_ENV_TYPE \
         -v $BASE_DIR/conf:/conf \
         -v $BASE_DIR/logs:/logs \
@@ -160,6 +166,28 @@ start_agent() {
     $RUN_CMD ps -f name="^/?controller" -f label=fivetran=ldp --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
 }
 
+restart_existing_agent_if_needed() {
+    # Check if a "controller" container exists (stopped or exited)
+    CONTAINER_ID=$($RUN_CMD ps -a -q -f name="^/?controller$" -f label=fivetran=ldp)
+
+    if [[ -n "$CONTAINER_ID" ]]; then
+        STATUS=$($RUN_CMD inspect --format '{{.State.Status}}' $CONTAINER_ID)
+        if [[ "$STATUS" == "exited" || "$STATUS" == "created" || "$STATUS" == "stopped" ]]; then
+            echo "Reusing existing stopped container: $CONTAINER_ID"
+            $RUN_CMD start $CONTAINER_ID
+            return
+        elif [[ "$STATUS" == "running" ]]; then
+            echo "Container $CONTAINER_ID is already running."
+            return
+        else
+            echo "Unexpected container status: $STATUS. Removing and recreating."
+            $RUN_CMD rm $CONTAINER_ID
+        fi
+    fi
+
+    echo "No suitable existing container found. Starting a new one."
+    start_agent
+}
 
 while getopts "r:h" opt; do
     case "$opt" in
@@ -191,7 +219,7 @@ ACTION="$1"
 
 # If no runtime specified, try docker first then podman.
 if [[ ! -n "$RUNTIME" ]]; then
-    if command -v docker &> /dev/null; then 
+    if command -v docker &> /dev/null; then
         RUNTIME="docker"
     elif command -v podman &> /dev/null; then
         RUNTIME="podman"
@@ -208,7 +236,7 @@ set_environment $RUNTIME
 case "$ACTION" in
     start)
         echo "Starting Hybrid Deployment agent using $RUNTIME"
-        start_agent
+        restart_existing_agent_if_needed
         ;;
     stop)
         echo "Stop Hybrid Deployment agent..."

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -163,12 +163,14 @@ start_agent() {
         $AGENT_IMAGE -f /conf/config.json
 
     sleep 3
-    $RUN_CMD ps -f name="^/?controller" -f label=fivetran=ldp --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
+    $RUN_CMD 
+     po
+     d--format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
 }
 
 restart_existing_agent_if_needed() {
     # Check if a "controller" container exists (stopped or exited)
-    CONTAINER_ID=$($RUN_CMD ps -a -q -f name="^/?controller$" -f label=fivetran=ldp)
+    CONTAINER_ID=$($RUN_CMD ps -a -q -f name="^/^controller.*$" -f label=fivetran=ldp)
 
     if [[ -n "$CONTAINER_ID" ]]; then
         STATUS=$($RUN_CMD inspect --format '{{.State.Status}}' $CONTAINER_ID)


### PR DESCRIPTION
Changes include:
* Update README with example creation of UNIT for the agent - agent.service, to be used with systemd to start agent.  This is useful on system running podman where after system reboot podman does not always restart containers that was running.
* Update hdagent.sh script to include new function that will allow restarting existing container if it exist. 
