### PR TITLE
Adjust deployment name to be configurable

### DIFF
--- a/agent/Chart.yaml
+++ b/agent/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: hybrid-deployment-agent
 description: A Helm chart for the Hybrid Deployment Agent (Controller)
 type: application
-version: "0.3.0"
-appVersion: "0.3.0"
+version: "0.4.0"
+appVersion: "0.4.0"

--- a/agent/README.md
+++ b/agent/README.md
@@ -26,7 +26,8 @@ helm upgrade --install hd-agent \
  --namespace default \
  --set config.data_volume_pvc=YOUR_PERSISTENT_VOLUME_CLAIM \
  --set config.token="YOUR_TOKEN_HERE" \
- --version 0.2.0
+ --set config.namespace=default \
+ --version 0.4.0
  ```
 
 > Notes:

--- a/agent/templates/deployment.yaml
+++ b/agent/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hd-agent
+  name: {{ if .Values.config.kubernetes_agent_deployment_name }}{{ .Values.config.kubernetes_agent_deployment_name }}{{ else }}{{ .Release.Name }}{{ end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: hd-agent


### PR DESCRIPTION
Height ticket
Links https://fivetran.height.app/T-959700

Update include:
* Increase chart version to 0.4.0
* Update README
* Change deployment name to be configurable - can match helm deployment and not be fixed hd-agent