### PR TITLE
Add github action to generate sha256 hash when hdagent.sh updated

### DIFF
--- a/.github/workflows/generate-hdagent-hash.yml
+++ b/.github/workflows/generate-hdagent-hash.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  generate-hash:
+  generate-hdagent-hash:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/generate-hdagent-hash.yml
+++ b/.github/workflows/generate-hdagent-hash.yml
@@ -1,0 +1,34 @@
+name: Generate SHA256 hash for hdagent.sh
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'hdagent.sh'
+
+permissions:
+  contents: write
+
+jobs:
+  generate-hash:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Generate SHA256 hash
+        id: sha256
+        run: |
+          sha256sum hdagent.sh | awk '{print $1}' > hdagent.sh.sha256
+      - name: Commit and push hash file
+        run: |
+          git config --local user.name 'github-actions[bot]'
+          git config --local user.email 'github-actions[bot]@users.noreply.github.com'
+          git add hdagent.sh.sha256
+
+          if git diff --staged --quiet; then
+            echo "Hash is already up to date, no changes to commit."
+          else
+            git commit -m "Update hdagent.sh.sha256"
+            git push
+          fi

--- a/.github/workflows/generate-hdagent-hash.yml
+++ b/.github/workflows/generate-hdagent-hash.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Generate SHA256 hash
         run: |
-          sha256sum hdagent.sh | awk '{print $1}' > hdagent.sh.sha256
+          sha256sum hdagent.sh | cut -d' ' -f1 > hdagent.sh.sha256
       - name: Commit and push hash file
         run: |
           git config --local user.name 'github-actions[bot]'

--- a/.github/workflows/generate-hdagent-hash.yml
+++ b/.github/workflows/generate-hdagent-hash.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Generate SHA256 hash
-        id: sha256
         run: |
           sha256sum hdagent.sh | awk '{print $1}' > hdagent.sh.sha256
       - name: Commit and push hash file


### PR DESCRIPTION
New github action which will generate a hash of the `hdagent.sh` script every time it's updated. The hash will be saved to a file `hdagent.sh.sha256` at the root of the repo.