### PR TITLE
Cleanup values.yaml to just config and agent sections

### DIFF
--- a/agent/templates/_helpers.tpl
+++ b/agent/templates/_helpers.tpl
@@ -7,7 +7,8 @@ app.kubernetes.io/part-of: hybrid-deployment
 {{/* Merge in any custom labels set in values.yaml */}}
 {{- define "hd.labels" -}}
 {{- $defaultLabels := fromYaml (include "hd.required.labels" .) }}
-{{- $customLabels := .Values.labels | default dict }}
+{{- if .Values.labels }}{{- $customLabels := .Values.labels | default dict }}{{- else -}}{{- $customLabels := dict -}}{{- end -}}
+{{- /* Merge default and custom labels */ -}}
 {{- $mergedLabels := merge $defaultLabels $customLabels }}
 {{- toYaml $mergedLabels }}
 {{- end -}}

--- a/agent/templates/deployment.yaml
+++ b/agent/templates/deployment.yaml
@@ -29,10 +29,17 @@ spec:
       restartPolicy: Always
       containers:
         - name: hd-agent
-          image: {{ .Values.image }}
-          imagePullPolicy: {{ .Values.image_pull_policy }}
+          image: {{ if .Values.agent.image }}{{ .Values.agent.image }}{{ else }}{{ .Values.image }}{{ end }}
+          imagePullPolicy: {{ if .Values.agent.image_pull_policy }}{{ .Values.agent.image_pull_policy }}{{ else }}{{ .Values.image_pull_policy }}{{ end }}
           resources:
-            {{- toYaml .Values.agent.resources | nindent 12 }}
+            {{- if .Values.agent.resources }}{{ toYaml .Values.agent.resources | nindent 12 }}{{ else }}
+            requests:
+              cpu: 2
+              memory: 2Gi
+            limits:
+              cpu: 2
+              memory: 2Gi
+            {{- end }}
           ports:
             - containerPort: 8090
           livenessProbe:

--- a/agent/values.schema.json
+++ b/agent/values.schema.json
@@ -83,6 +83,35 @@
     "agent": {
       "type": "object",
       "properties": {
+        "image": {
+          "type": "string",
+          "description": "The container image to use for the agent",
+          "default": "us-docker.pkg.dev/prod-eng-fivetran-ldp/public-docker-us/ldp-agent:production"
+        },
+        "image_pull_policy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy for the container",
+          "default": "Always"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Custom labels to apply to resources",
+          "default": {}
+        },
+        "node_selector": {
+          "type": "object",
+          "description": "Node selector for scheduling the agent pod",
+          "default": {}
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Toleration for scheduling the agent pod"
+          },
+          "default": []
+        },
         "resources": {
           "type": "object",
           "properties": {
@@ -101,8 +130,7 @@
                   "description": "Requested memory for the agent container",
                   "default": "2Gi"
                 }
-              },
-              "required": ["cpu", "memory"]
+              }
             },
             "limits": {
               "type": "object",
@@ -111,22 +139,19 @@
                   "type": "string",
                   "pattern": "^[0-9]+(m)?$",
                   "description": "CPU limit for the agent container",
-                  "default": "4"
+                  "default": "2"
                 },
                 "memory": {
                   "type": "string",
                   "pattern": "^[0-9]+(Mi|Gi)$",
                   "description": "Memory limit for the agent container",
-                  "default": "4Gi"
+                  "default": "2Gi"
                 }
-              },
-              "required": ["cpu", "memory"]
+              }
             }
-          },
-          "required": ["requests", "limits"]
+          }
         }
-      },
-      "required": ["resources"]
+      }
     },
     "affinity_rules": {
       "type": "object",
@@ -165,7 +190,6 @@
       }
     }
   ],
-
-  "required": ["image", "image_pull_policy", "config", "agent"],
+  "required": ["config", "agent"],
   "additionalProperties": true
 }

--- a/agent/values.yaml
+++ b/agent/values.yaml
@@ -1,20 +1,9 @@
-image: "us-docker.pkg.dev/prod-eng-fivetran-ldp/public-docker-us/ldp-agent:production"
-image_pull_policy: "Always"
-
 config:
+  namespace:
   data_volume_pvc: 
   token:
-  annotations: {}
-
-labels: {}
-node_selector: {}
-tolerations: []
 
 agent:
-  resources:
-    requests:
-      cpu: "2000m"
-      memory: "2Gi"
-    limits:
-      cpu: "4000m"
-      memory: "4Gi"
+  image: "us-docker.pkg.dev/prod-eng-fivetran-ldp/public-docker-us/ldp-agent:production"
+  image_pull_policy: "Always"
+  node_selector: {}


### PR DESCRIPTION
* Cleanup default values.yaml to include just config and agent sections.  Include only required and important options.  Defaults will be used for rest and will be documented.