### PR TITLE
tweak (hybrid_deployment): Remove node selector empty default from values.yaml

### DIFF
--- a/agent/values.schema.json
+++ b/agent/values.schema.json
@@ -75,9 +75,14 @@
       },
       "required": ["data_volume_pvc", "token"]
     },
+    "labels": {
+      "type": "object",
+      "description": "Custom labels to apply to resources",
+      "default": {}
+    },
     "node_selector": {
       "type": "object",
-      "description": "Node selector for scheduling the job pod",
+      "description": "Node selector for scheduling the agent pod",
       "default": {}
     },
     "agent": {

--- a/agent/values.schema.json
+++ b/agent/values.schema.json
@@ -75,6 +75,11 @@
       },
       "required": ["data_volume_pvc", "token"]
     },
+    "node_selector": {
+      "type": "object",
+      "description": "Node selector for scheduling the job pod",
+      "default": {}
+    },
     "agent": {
       "type": "object",
       "properties": {

--- a/agent/values.schema.json
+++ b/agent/values.schema.json
@@ -75,16 +75,6 @@
       },
       "required": ["data_volume_pvc", "token"]
     },
-    "labels": {
-      "type": "object",
-      "description": "Custom labels to apply to resources",
-      "default": {}
-    },
-    "node_selector": {
-      "type": "object",
-      "description": "Node selector for scheduling the agent pod",
-      "default": {}
-    },
     "agent": {
       "type": "object",
       "properties": {

--- a/agent/values.yaml
+++ b/agent/values.yaml
@@ -6,4 +6,3 @@ config:
 agent:
   image: "us-docker.pkg.dev/prod-eng-fivetran-ldp/public-docker-us/ldp-agent:production"
   image_pull_policy: "Always"
-  node_selector: {}


### PR DESCRIPTION
Jira ticket
Closes : https://fivetran.atlassian.net/browse/RD-1006049

Description:
- Removed default empty `node_selector` from `agent` section in values.yaml. We decided yesterday to not show any empty default values, but rather document these settings for use. 