### PR TITLE
feature(rbac): Allow to get and list deployments to validate Agent configuration

### DIFF
--- a/agent/templates/rbac.yaml
+++ b/agent/templates/rbac.yaml
@@ -65,7 +65,7 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["update", "patch"]
+    verbs: ["get", "list", "update", "patch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
Update include:

- Add permission in RBAC for get and list deployment action. To be able to verify number of replicas, set for the Agent's deployment, add permissions to get and list deployments.