### PR TITLE
tweak(hybrid_deployment): Add container type label to controller container

### DIFF
--- a/hdagent.sh
+++ b/hdagent.sh
@@ -453,6 +453,7 @@ start_agent() {
         --label fivetran=ldp \
         --label ldp_process_id=default-controller-process-id \
         --label ldp_controller_id=$CONTROLLER_ID \
+        --label ldp_container_type=CONTROLLER \
         --security-opt label=disable \
         --name controller \
         --network $CONTAINER_NETWORK \


### PR DESCRIPTION
Update:

Add `ldp_container_type=CONTROLLER` label to support some customers wanting to rename the Controller container during install. This will enable auto upgrade and container cleanup to use the container type label instead of using custom container names which cause upgrade and cleanup to fail.