### PR TITLE
Set docker/podman agent container memory to 2G limit

### DIFF
--- a/hd-debug.sh
+++ b/hd-debug.sh
@@ -268,7 +268,7 @@ function log_disk_space () {
 function log_resources () {
     # Log the resource usage to a file
     cat /proc/cpuinfo > "$STATS_DIR/system_proc_cpuinfo.log" 2>&1
-    cat /proc/meminfo > "$STATS_DIRsystem_proc_meminfo.log" 2>&1
+    cat /proc/meminfo > "$STATS_DIR/system_proc_meminfo.log" 2>&1
     uptime > "$STATS_DIR/system_uptime.log" 2>&1
     uname -a > "$STATS_DIR/system_uname_a.log" 2>&1
 }

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -450,6 +450,7 @@ start_agent() {
         -d \
         --restart "on-failure:3" \
         --pull "always" \
+        --memory=2048m \
         --label fivetran=ldp \
         --label ldp_process_id=default-controller-process-id \
         --label ldp_controller_id=$CONTROLLER_ID \


### PR DESCRIPTION
The HD Agent does not require a lot of memory.  
* Set default to 2G in hdagent.sh on agent container startup