### PR TITLE
Custom K8s annotations for resources

### DIFF
--- a/agent/templates/_helpers.tpl
+++ b/agent/templates/_helpers.tpl
@@ -1,16 +1,13 @@
-{{/* ----- Required Labels ----- */}}
 {{- define "hd.required.labels" -}}
 app.kubernetes.io/app: {{ if .Release }}{{ .Release.Name }}{{ else }}default-app{{ end }}
 app.kubernetes.io/part-of: hybrid-deployment
 {{- end }}
 
-{{/* ----- Merge Labels ----- */}}
 {{- define "hd.labels" -}}
 {{- $vals := .Values }}
 {{- $defaultLabels := fromYaml (include "hd.required.labels" .) }}
-{{- $common := $vals.commonLabels | default dict }}
 {{- $extra := .labels | default dict }}
-{{- $merged := mergeOverwrite (deepCopy $defaultLabels) (deepCopy $common) (deepCopy $extra) }}
+{{- $merged := mergeOverwrite (deepCopy $defaultLabels) (deepCopy $extra) }}
 {{- if .name }}
   {{- $merged = mergeOverwrite $merged (dict "app.kubernetes.io/name" .name) }}
 {{- end }}
@@ -19,48 +16,9 @@ app.kubernetes.io/part-of: hybrid-deployment
 {{- end }}
 {{- end }}
 
-{{/* ----- Merge Annotations ----- */}}
 {{- define "hd.annotations" -}}
-{{- $vals := .Values }}
-{{- $common := $vals.commonAnnotations | default dict }}
 {{- $extra := .annotations | default dict }}
-{{- $merged := mergeOverwrite (deepCopy $common) (deepCopy $extra) }}
-{{- if gt (len $merged) 0 }}
-{{- toYaml $merged }}
+{{- if gt (len $extra) 0 }}
+{{- toYaml $extra }}
 {{- end }}
 {{- end }}
-
-{{/* ----- Generic Metadata ----- */}}
-{{- define "hd.metadata" -}}
-metadata:
-  {{- if .name }}
-  name: {{ .name }}
-  {{- end }}
-  {{- if not .clusterScoped }}
-  namespace: {{ if .Release }}{{ .Release.Namespace }}{{ else }}default{{ end }}
-  {{- end }}
-
-  {{- /* Labels */}}
-  {{- $labels := dict "Values" .Values "labels" (.labels | default dict) "name" .name }}
-  {{- $labelsYaml := include "hd.labels" $labels | trim }}
-  {{- if $labelsYaml }}
-  labels:
-{{ $labelsYaml | indent 4 }}
-  {{- end }}
-
-  {{- /* Annotations */}}
-  {{- if .annotations }}
-    {{- $annotations := dict "Values" .Values "annotations" (.annotations | default dict) }}
-    {{- $annotationsYaml := include "hd.annotations" $annotations | trim }}
-    {{- if $annotationsYaml }}
-  annotations:
-{{ $annotationsYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-
-
-
-
-
-

--- a/agent/templates/_helpers.tpl
+++ b/agent/templates/_helpers.tpl
@@ -1,13 +1,66 @@
-{{/* Define required labels to use */}}
+{{/* ----- Required Labels ----- */}}
 {{- define "hd.required.labels" -}}
-app.kubernetes.io/app: {{ .Release.Name }}
+app.kubernetes.io/app: {{ if .Release }}{{ .Release.Name }}{{ else }}default-app{{ end }}
 app.kubernetes.io/part-of: hybrid-deployment
-{{- end -}}
+{{- end }}
 
-{{/* Merge in any custom labels set in values.yaml */}}
+{{/* ----- Merge Labels ----- */}}
 {{- define "hd.labels" -}}
+{{- $vals := .Values }}
 {{- $defaultLabels := fromYaml (include "hd.required.labels" .) }}
-{{- $customLabels := .Values.labels | default dict }}
-{{- $mergedLabels := merge $defaultLabels $customLabels }}
-{{- toYaml $mergedLabels }}
-{{- end -}}
+{{- $common := $vals.commonLabels | default dict }}
+{{- $extra := .labels | default dict }}
+{{- $merged := mergeOverwrite (deepCopy $defaultLabels) (deepCopy $common) (deepCopy $extra) }}
+{{- if .name }}
+  {{- $merged = mergeOverwrite $merged (dict "app.kubernetes.io/name" .name) }}
+{{- end }}
+{{- if gt (len $merged) 0 }}
+{{- toYaml $merged }}
+{{- end }}
+{{- end }}
+
+{{/* ----- Merge Annotations ----- */}}
+{{- define "hd.annotations" -}}
+{{- $vals := .Values }}
+{{- $common := $vals.commonAnnotations | default dict }}
+{{- $extra := .annotations | default dict }}
+{{- $merged := mergeOverwrite (deepCopy $common) (deepCopy $extra) }}
+{{- if gt (len $merged) 0 }}
+{{- toYaml $merged }}
+{{- end }}
+{{- end }}
+
+{{/* ----- Generic Metadata ----- */}}
+{{- define "hd.metadata" -}}
+metadata:
+  {{- if .name }}
+  name: {{ .name }}
+  {{- end }}
+  {{- if not .clusterScoped }}
+  namespace: {{ if .Release }}{{ .Release.Namespace }}{{ else }}default{{ end }}
+  {{- end }}
+
+  {{- /* Labels */}}
+  {{- $labels := dict "Values" .Values "labels" (.labels | default dict) "name" .name }}
+  {{- $labelsYaml := include "hd.labels" $labels | trim }}
+  {{- if $labelsYaml }}
+  labels:
+{{ $labelsYaml | indent 4 }}
+  {{- end }}
+
+  {{- /* Annotations */}}
+  {{- if .annotations }}
+    {{- $annotations := dict "Values" .Values "annotations" (.annotations | default dict) }}
+    {{- $annotationsYaml := include "hd.annotations" $annotations | trim }}
+    {{- if $annotationsYaml }}
+  annotations:
+{{ $annotationsYaml | indent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+
+
+
+
+

--- a/agent/templates/_helpers.tpl
+++ b/agent/templates/_helpers.tpl
@@ -1,13 +1,12 @@
-{{- define "hd.required.labels" -}}
-app.kubernetes.io/app: {{ if .Release }}{{ .Release.Name }}{{ else }}default-app{{ end }}
-app.kubernetes.io/part-of: hybrid-deployment
-{{- end }}
-
 {{- define "hd.labels" -}}
-{{- $vals := .Values }}
-{{- $defaultLabels := fromYaml (include "hd.required.labels" .) }}
+{{- $required := dict "app.kubernetes.io/part-of" "hybrid-deployment" }}
+{{- if .Release }}
+  {{- $required = mergeOverwrite $required (dict "app.kubernetes.io/app" .Release.Name) }}
+{{- else }}
+  {{- $required = mergeOverwrite $required (dict "app.kubernetes.io/app" "default-app") }}
+{{- end }}
 {{- $extra := .labels | default dict }}
-{{- $merged := mergeOverwrite (deepCopy $defaultLabels) (deepCopy $extra) }}
+{{- $merged := mergeOverwrite (deepCopy $required) (deepCopy $extra) }}
 {{- if .name }}
   {{- $merged = mergeOverwrite $merged (dict "app.kubernetes.io/name" .name) }}
 {{- end }}

--- a/agent/templates/deployment.yaml
+++ b/agent/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "hd.labels" . | nindent 8 }}
       annotations:
         helm.fivetran.com/chart-version: "{{ .Chart.Version }}"
+        {{- include "hd.annotations" (dict "Values" .Values "annotations" .Values.config.deployment_annotations) | nindent 8 }}
     spec:
       serviceAccountName: hd-agent-sa
       {{- if or .Values.agent.node_selector .Values.node_selector }}

--- a/agent/templates/deployment.yaml
+++ b/agent/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: hd-agent
-      {{- include "hd.required.labels" . | nindent 6 }}
+      {{- include "hd.labels" . | nindent 6 }}
   template:
     metadata:
       labels:

--- a/agent/templates/rbac.yaml
+++ b/agent/templates/rbac.yaml
@@ -1,17 +1,22 @@
+---
 apiVersion: v1
 kind: ServiceAccount
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-job-sa") | nindent 0 }}
+metadata:
+  name: hd-job-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-job-sa") | nindent 4 }}
+  annotations:
+    {{- include "hd.annotations" (dict "Values" .Values "annotations" .Values.config.sa_annotations) | nindent 4 }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-job-role") | nindent 0 }}
+metadata:
+  name: hd-job-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-job-role") | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -20,10 +25,11 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-job-rolebinding") | nindent 0 }}
+metadata:
+  name: hd-job-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-job-rolebinding") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: hd-job-sa
@@ -36,19 +42,22 @@ roleRef:
 ---
 apiVersion: v1
 kind: ServiceAccount
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-agent-sa" 
-      "annotations" .Values.config.sa_annotations) | nindent 0 }}
+metadata:
+  name: hd-agent-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-agent-sa") | nindent 4 }}
+  annotations:
+    {{- include "hd.annotations" (dict "Values" .Values "annotations" .Values.config.sa_annotations) | nindent 4 }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-agent-role") | nindent 0 }}
+metadata:
+  name: hd-agent-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-agent-role") | nindent 4 }}
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
@@ -75,10 +84,11 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-agent-rolebinding") | nindent 0 }}
+metadata:
+  name: hd-agent-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-agent-rolebinding") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: hd-agent-sa
@@ -91,21 +101,24 @@ roleRef:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-agent-event-reader") | nindent 0 }}
+metadata:
+  name: hd-agent-event-reader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-agent-event-reader") | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-{{- include "hd.metadata" (dict 
-      "Values" .Values 
-      "Release" .Release 
-      "name" "hd-agent-event-reader-binding") | nindent 0 }}
+metadata:
+  name: hd-agent-event-reader-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hd.labels" (dict "Values" .Values "name" "hd-agent-event-reader-binding") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: hd-agent-sa
@@ -114,4 +127,3 @@ roleRef:
   kind: Role
   name: hd-agent-event-reader
   apiGroup: rbac.authorization.k8s.io
-

--- a/agent/templates/rbac.yaml
+++ b/agent/templates/rbac.yaml
@@ -1,23 +1,17 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
-  # Used by Hybrid Deployment Jobs
-  name: hd-job-sa
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: hd-job-sa
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-job-sa") | nindent 0 }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
-  # Role that will be used by HD jobs
-  namespace: {{ .Release.Namespace }}
-  name: hd-job-role
-  labels:
-    app.kubernetes.io/name: hd-job-role
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-job-role") | nindent 0 }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -26,12 +20,10 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
-  name: hd-job-rolebinding
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: hd-job-rolebinding
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-job-rolebinding") | nindent 0 }}
 subjects:
   - kind: ServiceAccount
     name: hd-job-sa
@@ -44,24 +36,19 @@ roleRef:
 ---
 apiVersion: v1
 kind: ServiceAccount
-metadata:
-  # Used by Hybrid Deployment Agent
-  name: hd-agent-sa
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: hd-agent-sa
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-agent-sa" 
+      "annotations" .Values.config.sa_annotations) | nindent 0 }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
-  # Role used by HD Agent
-  namespace: {{ .Release.Namespace }}
-  name: hd-agent-role
-  labels:
-    app.kubernetes.io/name: hd-agent-role
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-agent-role") | nindent 0 }}
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
@@ -88,12 +75,10 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
-  name: hd-agent-rolebinding
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: hd-agent-rolebinding
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-agent-rolebinding") | nindent 0 }}
 subjects:
   - kind: ServiceAccount
     name: hd-agent-sa
@@ -106,12 +91,10 @@ roleRef:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: hd-agent-event-reader
-  labels:
-    app.kubernetes.io/name: hd-agent-event-reader
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-agent-event-reader") | nindent 0 }}
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -119,12 +102,10 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
-  name: hd-agent-event-reader-binding
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: hd-agent-event-reader-binding
-    {{- include "hd.labels" . | nindent 4 }}
+{{- include "hd.metadata" (dict 
+      "Values" .Values 
+      "Release" .Release 
+      "name" "hd-agent-event-reader-binding") | nindent 0 }}
 subjects:
   - kind: ServiceAccount
     name: hd-agent-sa


### PR DESCRIPTION
This change allows us to quickly add annotation fields to various resources defined within our helm chart. Currently limited to deployment and service account annotations as those are the most commonly requested. Should other resources be required, simply add the following:

- An annotation block to the resource, like the following:
`annotations:
    {{- include "hd.annotations" (dict "Values" .Values "annotations" .Values.config.resource_annotations) | nindent 4 }}`
- A value in the config.yaml, referencing the annotation object to use (in this case, `resource_annotations`)