### PR TITLE
Support custom labels in deployment selectors

### DIFF
--- a/agent/templates/_helpers.tpl
+++ b/agent/templates/_helpers.tpl
@@ -21,7 +21,9 @@
 {{- end }}
 
 {{- define "hd.selectorLabels" -}}
-{{- toYaml (dict "app.kubernetes.io/part-of" "hybrid-deployment" "app.kubernetes.io/app" .Release.Name) }}
+{{- $base := dict "app.kubernetes.io/part-of" "hybrid-deployment" "app.kubernetes.io/app" .Release.Name }}
+{{- $extra := .Values.labels | default dict }}
+{{- toYaml (mergeOverwrite $base $extra) }}
 {{- end }}
 
 {{- define "hd.annotations" -}}


### PR DESCRIPTION
## Summary

Enhance the `hd.selectorLabels` helper template to support custom labels from `.Values.labels`. Apply the same label merging pattern used in hd.labels to hd.selectorLabels.
This enables users to provide custom labels via .Values.labels that will be
included in both pod labels and deployment selectors.

Benefits:
- Consistent labels across pods and deployment selectors
- Essential for GitOps workflows where labels are part of deployment spec
- Follows existing pattern from hd.labels helper

Observation:
- For existing setups already using the hd.labels field, the deployment object must be recreated since deployment labels are immutable, which will trigger an agent restart.  