### PR TITLE
fix(hybrid_deployment/agent): grant events.k8s.io API group access to hd-agent-event-reader role

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ helm upgrade --install hd-agent \
  --set config.data_volume_pvc=YOUR_PERSISTENT_VOLUME_CLAIM \
  --set config.token="YOUR_TOKEN_HERE" \
  --set config.namespace=fivetran \
- --version 0.20.0
+ --version 0.21.0
  ```
 
 > Notes:

--- a/agent/Chart.yaml
+++ b/agent/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: hybrid-deployment-agent
 description: A Helm chart for the Hybrid Deployment Agent (Controller)
 type: application
-version: "0.20.0"
-appVersion: "0.20.0"
+version: "0.21.0"
+appVersion: "0.21.0"

--- a/agent/README.md
+++ b/agent/README.md
@@ -43,7 +43,7 @@ helm upgrade --install hd-agent \
  --set config.data_volume_pvc=YOUR_PERSISTENT_VOLUME_CLAIM \
  --set config.token="YOUR_TOKEN_HERE" \
  --set config.namespace=fivetran \
- --version 0.20.0
+ --version 0.21.0
  ```
 
 > Notes:
@@ -70,7 +70,7 @@ helm upgrade --install hd-agent \
  -f values.yaml \
  --create-namespace \
  --namespace fivetran \
- --version 0.20.0
+ --version 0.21.0
 ```
 
 Example values file:
@@ -176,7 +176,7 @@ helm upgrade --install hd-agent \
  --set agent.jvm_xmx=1024m \
  --create-namespace \
  --namespace fivetran \
- --version 0.20.0
+ --version 0.21.0
 ```
 
 > **Note:** JVM memory values support standard Java memory units (e.g., 800m, 1g, 2G). Ensure the JVM memory settings are appropriate for your container memory limits and that both values match for optimal performance.

--- a/agent/templates/rbac.yaml
+++ b/agent/templates/rbac.yaml
@@ -119,7 +119,7 @@ metadata:
   labels:
     {{- include "hd.labels" (dict "Values" .Values "name" "hd-agent-event-reader") | nindent 4 }}
 rules:
-  - apiGroups: [""]
+  - apiGroups: ["", "events.k8s.io"]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
 


### PR DESCRIPTION
The role only covered core v1 events ("" apiGroup). Modern Kubernetes client libraries default to events.k8s.io/v1, causing 403 Forbidden when the agent watches events for pods in the namespace.