### PR TITLE
Add clock skew diagnostics to HD scripts

### DIFF
--- a/hd-debug.sh
+++ b/hd-debug.sh
@@ -57,6 +57,8 @@ STATS_DIR="$BASE_DIR/stats"
 mkdir -p $STATS_DIR 2>/dev/null
 echo -e "Stats location: $STATS_DIR\n"
 
+CLOCK_SKEW_WARNING_THRESHOLD_SECONDS=30
+CLOCK_SKEW_ERROR_THRESHOLD_SECONDS=60
 CONFIG_FILE=$BASE_DIR/conf/config.json
 LOGDIR=$BASE_DIR/logs
 TOKEN=""
@@ -287,6 +289,26 @@ function log_network_stats () {
     cat /etc/resolv.conf |grep -v "^#" > "$STATS_DIR/system_etc_resolv_conf.log" 2>&1
 }
 
+function log_time_sync_status() {
+    if command -v timedatectl &> /dev/null; then
+        timedatectl status > "$STATS_DIR/system_timedatectl_status.log" 2>&1
+    else
+        echo "timedatectl is not installed/used or not in the PATH." > "$STATS_DIR/system_timedatectl_status.log"
+    fi
+
+    if command -v chronyc &> /dev/null; then
+        chronyc tracking > "$STATS_DIR/system_chronyc_tracking.log" 2>&1
+    else
+        echo "chronyc is not installed/used or not in the PATH." > "$STATS_DIR/system_chronyc_tracking.log"
+    fi
+
+    if command -v ntpq &> /dev/null; then
+        ntpq -p > "$STATS_DIR/system_ntpq_p.log" 2>&1
+    else
+        echo "ntpq is not installed/used or not in the PATH." > "$STATS_DIR/system_ntpq_p.log"
+    fi
+}
+
 function log_user () {
     # Log the user information to a file
     whoami > "$STATS_DIR/current_user.log" 2>&1
@@ -373,6 +395,101 @@ function test_orchestrator_com () {
     curl -v https://ldp.orchestrator.fivetran.com > "$STATS_DIR/connectivity_orchestrator_fivetran_com.log" 2>&1
 }
 
+function get_reference_endpoint_http_date() {
+    local time_check_urls=(
+        "https://api.fivetran.com/v1/hybrid-deployment-agents"
+        "https://ldp.orchestrator.fivetran.com"
+    )
+    local url=""
+    local response_headers=""
+    local server_date_header=""
+
+    for url in "${time_check_urls[@]}"; do
+        response_headers=$(curl -sSI --max-time 5 "$url" 2>/dev/null)
+        server_date_header=$(printf "%s\n" "$response_headers" | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')
+        if [[ -n "$server_date_header" ]]; then
+            echo "${url}|${server_date_header}"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+function log_clock_skew_check() {
+    local log_file="$STATS_DIR/system_clock_skew_check.log"
+    local local_utc_time=""
+    local local_epoch=""
+    local reference_info=""
+    local reference_url=""
+    local reference_http_date=""
+    local reference_epoch=""
+    local skew_seconds=0
+    local absolute_skew_seconds=0
+    local skew_direction="in sync"
+    local status="OK"
+
+    local_utc_time=$(date -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null)
+    local_epoch=$(date -u +%s 2>/dev/null)
+
+    {
+        echo "Clock skew diagnostic"
+        echo "Local UTC time: ${local_utc_time:-unavailable}"
+    } > "$log_file"
+
+    if ! command -v curl &> /dev/null; then
+        echo "Result: curl not available, unable to determine HTTP Date from a reachable endpoint." >> "$log_file"
+        return
+    fi
+
+    if [[ -z "$local_epoch" ]]; then
+        echo "Result: unable to determine local system time." >> "$log_file"
+        return
+    fi
+
+    reference_info=$(get_reference_endpoint_http_date)
+    if [[ -z "$reference_info" ]]; then
+        echo "Result: unable to determine HTTP Date from a reachable endpoint." >> "$log_file"
+        return
+    fi
+
+    reference_url=${reference_info%%|*}
+    reference_http_date=${reference_info#*|}
+    # date -d is GNU date syntax, which is available on supported Linux hosts.
+    reference_epoch=$(date -u -d "$reference_http_date" +%s 2>/dev/null)
+
+    {
+        echo "Reference endpoint: $reference_url"
+        echo "Reference HTTP Date: $reference_http_date"
+    } >> "$log_file"
+
+    if [[ -z "$reference_epoch" ]]; then
+        echo "Result: unable to parse HTTP Date from reachable endpoint." >> "$log_file"
+        return
+    fi
+
+    skew_seconds=$((local_epoch - reference_epoch))
+    absolute_skew_seconds=${skew_seconds#-}
+
+    if (( skew_seconds > 0 )); then
+        skew_direction="ahead"
+    elif (( skew_seconds < 0 )); then
+        skew_direction="behind"
+    fi
+
+    if (( absolute_skew_seconds >= CLOCK_SKEW_ERROR_THRESHOLD_SECONDS )); then
+        status="ERROR-LIKE"
+    elif (( absolute_skew_seconds >= CLOCK_SKEW_WARNING_THRESHOLD_SECONDS )); then
+        status="WARNING"
+    fi
+
+    {
+        echo "Clock skew: ${absolute_skew_seconds}s (${skew_direction})"
+        echo "Thresholds: warning>=${CLOCK_SKEW_WARNING_THRESHOLD_SECONDS}s error>=${CLOCK_SKEW_ERROR_THRESHOLD_SECONDS}s"
+        echo "Status: $status"
+    } >> "$log_file"
+}
+
 function get_conntrack_values() {
     # Review current conntrack values
     cat /proc/sys/net/netfilter/nf_conntrack_count > "$STATS_DIR/system_proc_sys_net_netfilter_nf_conntrack_count.log"
@@ -456,6 +573,8 @@ log_config
 log_hdagent_logs
 log_resources
 log_network_stats
+log_time_sync_status
+log_clock_skew_check
 get_conntrack_values
 
 if [[ "$EXCLUDE_ENV" == "true" ]]; 
@@ -485,4 +604,3 @@ cd -
 
 echo -e "done.\n"
 echo -e "Logs are available in $STATS_DIR/logs-$CONTROLLER_ID.tar.gz\n"
-

--- a/hd-debug.sh
+++ b/hd-debug.sh
@@ -58,7 +58,7 @@ mkdir -p $STATS_DIR 2>/dev/null
 echo -e "Stats location: $STATS_DIR\n"
 
 CLOCK_SKEW_WARNING_THRESHOLD_SECONDS=30
-CLOCK_SKEW_ERROR_THRESHOLD_SECONDS=60
+CLOCK_SKEW_REFERENCE_URL="https://ldp.orchestrator.fivetran.com"
 CONFIG_FILE=$BASE_DIR/conf/config.json
 LOGDIR=$BASE_DIR/logs
 TOKEN=""
@@ -289,26 +289,6 @@ function log_network_stats () {
     cat /etc/resolv.conf |grep -v "^#" > "$STATS_DIR/system_etc_resolv_conf.log" 2>&1
 }
 
-function log_time_sync_status() {
-    if command -v timedatectl &> /dev/null; then
-        timedatectl status > "$STATS_DIR/system_timedatectl_status.log" 2>&1
-    else
-        echo "timedatectl is not installed/used or not in the PATH." > "$STATS_DIR/system_timedatectl_status.log"
-    fi
-
-    if command -v chronyc &> /dev/null; then
-        chronyc tracking > "$STATS_DIR/system_chronyc_tracking.log" 2>&1
-    else
-        echo "chronyc is not installed/used or not in the PATH." > "$STATS_DIR/system_chronyc_tracking.log"
-    fi
-
-    if command -v ntpq &> /dev/null; then
-        ntpq -p > "$STATS_DIR/system_ntpq_p.log" 2>&1
-    else
-        echo "ntpq is not installed/used or not in the PATH." > "$STATS_DIR/system_ntpq_p.log"
-    fi
-}
-
 function log_user () {
     # Log the user information to a file
     whoami > "$STATS_DIR/current_user.log" 2>&1
@@ -395,98 +375,36 @@ function test_orchestrator_com () {
     curl -v https://ldp.orchestrator.fivetran.com > "$STATS_DIR/connectivity_orchestrator_fivetran_com.log" 2>&1
 }
 
-function get_reference_endpoint_http_date() {
-    local time_check_urls=(
-        "https://api.fivetran.com/v1/hybrid-deployment-agents"
-        "https://ldp.orchestrator.fivetran.com"
-    )
-    local url=""
-    local response_headers=""
-    local server_date_header=""
-
-    for url in "${time_check_urls[@]}"; do
-        response_headers=$(curl -sSI --max-time 5 "$url" 2>/dev/null)
-        server_date_header=$(printf "%s\n" "$response_headers" | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')
-        if [[ -n "$server_date_header" ]]; then
-            echo "${url}|${server_date_header}"
-            return 0
-        fi
-    done
-
-    return 1
-}
-
 function log_clock_skew_check() {
     local log_file="$STATS_DIR/system_clock_skew_check.log"
-    local local_utc_time=""
-    local local_epoch=""
-    local reference_info=""
-    local reference_url=""
-    local reference_http_date=""
-    local reference_epoch=""
-    local skew_seconds=0
-    local absolute_skew_seconds=0
-    local skew_direction="in sync"
-    local status="OK"
+    local server_date server_epoch local_epoch abs_skew
 
-    local_utc_time=$(date -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null)
-    local_epoch=$(date -u +%s 2>/dev/null)
+    server_date=$(curl -sSI --max-time 5 "$CLOCK_SKEW_REFERENCE_URL" 2>/dev/null \
+        | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')
+    server_epoch=$(date -u -d "$server_date" +%s 2>/dev/null || true)
+    local_epoch=$(date -u +%s 2>/dev/null || true)
 
     {
         echo "Clock skew diagnostic"
-        echo "Local UTC time: ${local_utc_time:-unavailable}"
+        echo "Local UTC time: $(date -u +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || echo unavailable)"
+        echo "Reference endpoint: $CLOCK_SKEW_REFERENCE_URL"
+        echo "Reference HTTP Date: $server_date"
     } > "$log_file"
 
-    if ! command -v curl &> /dev/null; then
-        echo "Result: curl not available, unable to determine HTTP Date from a reachable endpoint." >> "$log_file"
+    [[ -n "$server_date" ]] || {
+        echo "Result: unable to determine HTTP Date from reference endpoint." >> "$log_file"
         return
-    fi
-
-    if [[ -z "$local_epoch" ]]; then
+    }
+    [[ -n "$server_epoch" && -n "$local_epoch" ]] || {
         echo "Result: unable to determine local system time." >> "$log_file"
         return
-    fi
+    }
 
-    reference_info=$(get_reference_endpoint_http_date)
-    if [[ -z "$reference_info" ]]; then
-        echo "Result: unable to determine HTTP Date from a reachable endpoint." >> "$log_file"
-        return
-    fi
-
-    reference_url=${reference_info%%|*}
-    reference_http_date=${reference_info#*|}
-    # date -d is GNU date syntax, which is available on supported Linux hosts.
-    reference_epoch=$(date -u -d "$reference_http_date" +%s 2>/dev/null)
-
+    abs_skew=$(( local_epoch > server_epoch ? local_epoch - server_epoch : server_epoch - local_epoch ))
     {
-        echo "Reference endpoint: $reference_url"
-        echo "Reference HTTP Date: $reference_http_date"
-    } >> "$log_file"
-
-    if [[ -z "$reference_epoch" ]]; then
-        echo "Result: unable to parse HTTP Date from reachable endpoint." >> "$log_file"
-        return
-    fi
-
-    skew_seconds=$((local_epoch - reference_epoch))
-    absolute_skew_seconds=${skew_seconds#-}
-
-    if (( skew_seconds > 0 )); then
-        skew_direction="ahead"
-    elif (( skew_seconds < 0 )); then
-        skew_direction="behind"
-    fi
-
-    if (( absolute_skew_seconds >= CLOCK_SKEW_ERROR_THRESHOLD_SECONDS )); then
-        status="ERROR-LIKE"
-    elif (( absolute_skew_seconds >= CLOCK_SKEW_WARNING_THRESHOLD_SECONDS )); then
-        status="WARNING"
-    fi
-
-    {
-        echo "Clock skew: ${absolute_skew_seconds}s (${skew_direction})"
-        echo "Thresholds: warning>=${CLOCK_SKEW_WARNING_THRESHOLD_SECONDS}s error>=${CLOCK_SKEW_ERROR_THRESHOLD_SECONDS}s"
-        echo "Status: $status"
+        echo "Clock skew: ${abs_skew}s"
+        echo "Threshold: warning>${CLOCK_SKEW_WARNING_THRESHOLD_SECONDS}s"
+        echo "Status: $([[ $abs_skew -gt $CLOCK_SKEW_WARNING_THRESHOLD_SECONDS ]] && echo WARNING || echo OK)"
     } >> "$log_file"
 }
 
@@ -573,7 +491,6 @@ log_config
 log_hdagent_logs
 log_resources
 log_network_stats
-log_time_sync_status
 log_clock_skew_check
 get_conntrack_values
 

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -417,7 +417,7 @@ check_clock_skew() {
 
     abs_skew=$(( local_epoch > server_epoch ? local_epoch - server_epoch : server_epoch - local_epoch ))
     if (( abs_skew > CLOCK_SKEW_WARNING_THRESHOLD_SECONDS )); then
-        WARNINGS+=("System clock differs from HTTP Date reported by ${CLOCK_SKEW_REFERENCE_URL} by ${abs_skew}s. Verify NTP synchronization before running setup tests")
+        WARNINGS+=("System clock differs from the reference time by ${abs_skew}s. Clock skew can cause some connector syncs to fail. Verify NTP synchronization before running setup tests")
     fi
 }
 

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -403,6 +403,11 @@ check_service_reachability() {
 }
 
 check_clock_skew() {
+    if ! command -v curl &> /dev/null; then
+        WARNINGS+=("curl not available, skipping clock skew check")
+        return
+    fi
+
     local server_date
     server_date=$(curl -sSI --max-time "${TIMEOUT}" "$CLOCK_SKEW_REFERENCE_URL" 2>/dev/null \
         | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -24,6 +24,8 @@ fi
 MIN_DOCKER_VERSION="20.10.17"
 MIN_PODMAN_VERSION="4.5.0"
 TIMEOUT=5
+CLOCK_SKEW_WARNING_THRESHOLD_SECONDS=30
+CLOCK_SKEW_ERROR_THRESHOLD_SECONDS=60
 
 BASE_DIR=$(pwd)
 SCRIPT_PATH="$(realpath "$0")"
@@ -44,6 +46,7 @@ RUNTIME=""
 INTERNAL_SOCKET=""
 CONTAINER_ENV_TYPE=""
 SKIP_CHECKS=""
+CLOCK_SKEW_REFERENCE_REACHABLE="false"
 WARNINGS=()
 ERRORS=()
 
@@ -396,8 +399,78 @@ check_service_reachability() {
         if ! curl -s --max-time ${TIMEOUT} -o /dev/null "$url" 2>/dev/null; then
             local name=$(echo "$url" | sed 's|https://||' | sed 's|/.*||')
             ERRORS+=("$name is not reachable")
+        else
+            CLOCK_SKEW_REFERENCE_REACHABLE="true"
         fi
     done
+}
+
+get_fivetran_service_time_epoch() {
+    local time_check_urls=(
+        "https://api.fivetran.com/v1/hybrid-deployment-agents"
+        "https://ldp.orchestrator.fivetran.com"
+    )
+    local url=""
+    local response_headers=""
+    local server_date_header=""
+    local server_epoch=""
+
+    for url in "${time_check_urls[@]}"; do
+        response_headers=$(curl -sSI --max-time ${TIMEOUT} "$url" 2>/dev/null)
+        server_date_header=$(printf "%s\n" "$response_headers" | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')
+        if [[ -n "$server_date_header" ]]; then
+            # date -d is GNU date syntax, which is available on supported Linux hosts.
+            server_epoch=$(date -u -d "$server_date_header" +%s 2>/dev/null)
+            if [[ -n "$server_epoch" ]]; then
+                echo "$server_epoch"
+                return 0
+            fi
+        fi
+    done
+
+    return 1
+}
+
+check_clock_skew() {
+    local server_epoch=""
+    local local_epoch=""
+    local skew_seconds=0
+    local absolute_skew_seconds=0
+    local skew_direction="in sync"
+    local skew_message=""
+
+    if [[ "$CLOCK_SKEW_REFERENCE_REACHABLE" != "true" ]]; then
+        return
+    fi
+
+    server_epoch=$(get_fivetran_service_time_epoch)
+    if [[ -z "$server_epoch" ]]; then
+        WARNINGS+=("Unable to determine HTTP Date reported by a reachable endpoint, skipping clock skew check")
+        return
+    fi
+
+    local_epoch=$(date -u +%s 2>/dev/null)
+    if [[ -z "$local_epoch" ]]; then
+        WARNINGS+=("Unable to determine local system time, skipping clock skew check")
+        return
+    fi
+
+    skew_seconds=$((local_epoch - server_epoch))
+    absolute_skew_seconds=${skew_seconds#-}
+
+    if (( skew_seconds > 0 )); then
+        skew_direction="ahead"
+    elif (( skew_seconds < 0 )); then
+        skew_direction="behind"
+    fi
+
+    skew_message="System clock differs from HTTP Date reported by a reachable endpoint by ${absolute_skew_seconds}s (${skew_direction})"
+
+    if (( absolute_skew_seconds >= CLOCK_SKEW_ERROR_THRESHOLD_SECONDS )); then
+        ERRORS+=("Clock skew check failed: ${skew_message}. The agent will not start because clock skew at or above ${CLOCK_SKEW_ERROR_THRESHOLD_SECONDS}s can cause JWT token validation failures. Synchronize the host with NTP and retry")
+    elif (( absolute_skew_seconds >= CLOCK_SKEW_WARNING_THRESHOLD_SECONDS )); then
+        WARNINGS+=("${skew_message}. Verify NTP synchronization before running setup tests")
+    fi
 }
 
 setup_kerberos_auth_if_enabled() {
@@ -465,6 +538,7 @@ validate_prerequisites() {
     check_rootless_linger
     check_config
     check_service_reachability
+    check_clock_skew
 
     if [ ${#WARNINGS[@]} -gt 0 ] || [ ${#ERRORS[@]} -gt 0 ]; then
         echo ""

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -25,7 +25,7 @@ MIN_DOCKER_VERSION="20.10.17"
 MIN_PODMAN_VERSION="4.5.0"
 TIMEOUT=5
 CLOCK_SKEW_WARNING_THRESHOLD_SECONDS=30
-CLOCK_SKEW_ERROR_THRESHOLD_SECONDS=60
+CLOCK_SKEW_REFERENCE_URL="https://ldp.orchestrator.fivetran.com"
 
 BASE_DIR=$(pwd)
 SCRIPT_PATH="$(realpath "$0")"
@@ -46,7 +46,6 @@ RUNTIME=""
 INTERNAL_SOCKET=""
 CONTAINER_ENV_TYPE=""
 SKIP_CHECKS=""
-CLOCK_SKEW_REFERENCE_REACHABLE="false"
 WARNINGS=()
 ERRORS=()
 
@@ -399,77 +398,26 @@ check_service_reachability() {
         if ! curl -s --max-time ${TIMEOUT} -o /dev/null "$url" 2>/dev/null; then
             local name=$(echo "$url" | sed 's|https://||' | sed 's|/.*||')
             ERRORS+=("$name is not reachable")
-        else
-            CLOCK_SKEW_REFERENCE_REACHABLE="true"
         fi
     done
-}
-
-get_fivetran_service_time_epoch() {
-    local time_check_urls=(
-        "https://api.fivetran.com/v1/hybrid-deployment-agents"
-        "https://ldp.orchestrator.fivetran.com"
-    )
-    local url=""
-    local response_headers=""
-    local server_date_header=""
-    local server_epoch=""
-
-    for url in "${time_check_urls[@]}"; do
-        response_headers=$(curl -sSI --max-time ${TIMEOUT} "$url" 2>/dev/null)
-        server_date_header=$(printf "%s\n" "$response_headers" | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')
-        if [[ -n "$server_date_header" ]]; then
-            # date -d is GNU date syntax, which is available on supported Linux hosts.
-            server_epoch=$(date -u -d "$server_date_header" +%s 2>/dev/null)
-            if [[ -n "$server_epoch" ]]; then
-                echo "$server_epoch"
-                return 0
-            fi
-        fi
-    done
-
-    return 1
 }
 
 check_clock_skew() {
-    local server_epoch=""
-    local local_epoch=""
-    local skew_seconds=0
-    local absolute_skew_seconds=0
-    local skew_direction="in sync"
-    local skew_message=""
+    local server_date
+    server_date=$(curl -sSI --max-time "${TIMEOUT}" "$CLOCK_SKEW_REFERENCE_URL" 2>/dev/null \
+        | awk 'tolower($0) ~ /^date:/ { sub(/\r$/, "", $0); print substr($0, 7); exit }')
 
-    if [[ "$CLOCK_SKEW_REFERENCE_REACHABLE" != "true" ]]; then
-        return
-    fi
-
-    server_epoch=$(get_fivetran_service_time_epoch)
-    if [[ -z "$server_epoch" ]]; then
-        WARNINGS+=("Unable to determine HTTP Date reported by a reachable endpoint, skipping clock skew check")
-        return
-    fi
-
-    local_epoch=$(date -u +%s 2>/dev/null)
-    if [[ -z "$local_epoch" ]]; then
+    local server_epoch local_epoch abs_skew
+    server_epoch=$(date -u -d "$server_date" +%s 2>/dev/null || true)
+    local_epoch=$(date -u +%s 2>/dev/null || true)
+    [[ -n "$server_date" && -n "$server_epoch" && -n "$local_epoch" ]] || {
         WARNINGS+=("Unable to determine local system time, skipping clock skew check")
         return
-    fi
+    }
 
-    skew_seconds=$((local_epoch - server_epoch))
-    absolute_skew_seconds=${skew_seconds#-}
-
-    if (( skew_seconds > 0 )); then
-        skew_direction="ahead"
-    elif (( skew_seconds < 0 )); then
-        skew_direction="behind"
-    fi
-
-    skew_message="System clock differs from HTTP Date reported by a reachable endpoint by ${absolute_skew_seconds}s (${skew_direction})"
-
-    if (( absolute_skew_seconds >= CLOCK_SKEW_ERROR_THRESHOLD_SECONDS )); then
-        ERRORS+=("Clock skew check failed: ${skew_message}. The agent will not start because clock skew at or above ${CLOCK_SKEW_ERROR_THRESHOLD_SECONDS}s can cause JWT token validation failures. Synchronize the host with NTP and retry")
-    elif (( absolute_skew_seconds >= CLOCK_SKEW_WARNING_THRESHOLD_SECONDS )); then
-        WARNINGS+=("${skew_message}. Verify NTP synchronization before running setup tests")
+    abs_skew=$(( local_epoch > server_epoch ? local_epoch - server_epoch : server_epoch - local_epoch ))
+    if (( abs_skew > CLOCK_SKEW_WARNING_THRESHOLD_SECONDS )); then
+        WARNINGS+=("System clock differs from HTTP Date reported by ${CLOCK_SKEW_REFERENCE_URL} by ${abs_skew}s. Verify NTP synchronization before running setup tests")
     fi
 }
 


### PR DESCRIPTION
Jira Ticket: https://fivetran.atlassian.net/browse/RD-1193317

## Summary
Add clock-skew detection to the Hybrid Deployment startup script so agent startup warns when host time is drifting and blocks when skew is large enough to cause JWT validation failures.

Also add non-blocking clock-skew diagnostics to the debug bundle so support can capture local time, endpoint HTTP Date, computed skew, and host time-sync status from customer environments.

## Why
We traced customer setup-test failures with `JWT token is invalid` to host clock skew. The startup script now catches that condition before the agent starts, and the debug script now records the same signal for troubleshooting.

## Verification:
### hdagent.sh output: (Clock Skew issue present )
<img width="1680" height="624" alt="Screenshot 2026-04-14 at 5 52 02 PM" src="https://github.com/user-attachments/assets/88eda15d-b455-413a-a554-65f048f7b307" />



### hd-debug.sh (Clock skew issue removed)
<img width="2225" height="957" alt="Screenshot 2026-04-14 at 5 41 34 PM" src="https://github.com/user-attachments/assets/2d40a26e-5f47-4010-827a-3b147ec22b31" />



