### PR TITLE
feature(hybrid_deployment/hdagent): Support custom DNS server configuration

### DIFF
--- a/agent/templates/deployment.yaml
+++ b/agent/templates/deployment.yaml
@@ -42,6 +42,17 @@ spec:
         {{- end }}
       {{- end }}
       restartPolicy: Always
+      {{- if .Values.config.custom_dns }}
+      dnsConfig:
+        nameservers:
+          {{- if kindIs "string" .Values.config.custom_dns }}
+          {{- range splitList "," .Values.config.custom_dns }}
+          - {{ trim . | quote }}
+          {{- end }}
+          {{- else }}
+          {{- toYaml .Values.config.custom_dns | nindent 10 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: hd-agent
           image: {{ if .Values.agent.image }}{{ .Values.agent.image }}{{ else }}{{ .Values.image }}{{ end }}

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -137,7 +137,7 @@ set_environment() {
 
     # Extract custom_dns from config file if present
     if [[ -f "$CONFIG_FILE" ]]; then
-        CUSTOM_DNS=$(grep -o '"custom_dns"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" | sed 's/.*"custom_dns"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+        CUSTOM_DNS=$(grep -o '"custom_dns"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" | head -1 | awk -F'"' '{print $4}')
     fi
 }
 
@@ -587,7 +587,7 @@ start_agent() {
 
     setup_kerberos_auth_if_enabled
 
-    DNS_ARGS=()
+    local DNS_ARGS=()
     if [[ -n "$CUSTOM_DNS" ]]; then
         DNS_ARGS=(--dns "$CUSTOM_DNS")
     fi

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -37,6 +37,7 @@ LOGDIR=$BASE_DIR/logs
 KERBEROS_KEYTAB_PATH=${KERBEROS_KEYTAB_PATH:-"$BASE_DIR/conf/krb5.keytab"}
 KERBEROS_KRB5_CONF_PATH=${KERBEROS_KRB5_CONF_PATH:-"$BASE_DIR/conf/krb5.conf"}
 KERBEROS_ENV_ARGS=()
+CUSTOM_DNS=""
 TOKEN=""
 CONTROLLER_ID=""
 SOCKET=""
@@ -132,6 +133,11 @@ set_environment() {
     if [[ $? -ne 0 ]]; then
         echo "Invalid controller-id format, please supply valid token"
         exit 1
+    fi
+
+    # Extract custom_dns from config file if present
+    if [[ -f "$CONFIG_FILE" ]]; then
+        CUSTOM_DNS=$(grep -o '"custom_dns"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" | sed 's/.*"custom_dns"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
     fi
 }
 
@@ -581,6 +587,11 @@ start_agent() {
 
     setup_kerberos_auth_if_enabled
 
+    DNS_ARGS=()
+    if [[ -n "$CUSTOM_DNS" ]]; then
+        DNS_ARGS=(--dns "$CUSTOM_DNS")
+    fi
+
     # create and run the agent container in background
     $RUN_CMD run \
         -d \
@@ -597,6 +608,7 @@ start_agent() {
         --env HOST_USER_HOME_DIR=$HOME \
         --env CONTAINER_ENV_TYPE=$CONTAINER_ENV_TYPE \
         "${KERBEROS_ENV_ARGS[@]}" \
+        "${DNS_ARGS[@]}" \
         -v $BASE_DIR/conf:/conf \
         -v $BASE_DIR/logs:/logs \
         -v $SOCKET:$INTERNAL_SOCKET \

--- a/hdagent.sh
+++ b/hdagent.sh
@@ -589,7 +589,11 @@ start_agent() {
 
     local DNS_ARGS=()
     if [[ -n "$CUSTOM_DNS" ]]; then
-        DNS_ARGS=(--dns "$CUSTOM_DNS")
+        IFS=',' read -ra _dns_list <<< "$CUSTOM_DNS"
+        for _dns_entry in "${_dns_list[@]}"; do
+            _dns_entry="${_dns_entry// /}"
+            [[ -n "$_dns_entry" ]] && DNS_ARGS+=(--dns "$_dns_entry")
+        done
     fi
 
     # create and run the agent container in background


### PR DESCRIPTION
## Summary

- Reads `custom_dns` string property from `conf/config.json` in `set_environment` and stores it in the `CUSTOM_DNS` variable
- Passes `--dns "$CUSTOM_DNS"` to the `docker run` / `podman run` command in `start_agent` when the value is non-empty
- No behavioural change when `custom_dns` is absent from the config