### PR TITLE
fix(hdagent): handle already-stopped containers on Podman

### DIFF
--- a/hdagent.sh
+++ b/hdagent.sh
@@ -547,8 +547,8 @@ stop_workers() {
            echo "Container '$container_prefix' does not exist"
         else
            echo "Stopping container '$container_prefix' (ID: $CONTAINER_ID)"
-	   $RUN_CMD stop $CONTAINER_ID > /dev/null 2>&1
-	   $RUN_CMD rm $CONTAINER_ID > /dev/null 2>&1
+	   $RUN_CMD stop $CONTAINER_ID > /dev/null 2>&1 || true
+	   $RUN_CMD rm $CONTAINER_ID > /dev/null 2>&1 || true
         fi
     done
 }
@@ -561,8 +561,8 @@ stop_agent() {
     else
         $RUN_CMD ps -f name="^/?controller" -f label=fivetran=ldp --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
         echo "Stopping agent and cleaning up container"
-        $RUN_CMD stop $CONTAINER_ID > /dev/null 2>&1
-        $RUN_CMD rm $CONTAINER_ID > /dev/null 2>&1
+        $RUN_CMD stop $CONTAINER_ID > /dev/null 2>&1 || true
+        $RUN_CMD rm $CONTAINER_ID > /dev/null 2>&1 || true
     fi
 }
 


### PR DESCRIPTION
## Summary
- Podman returns non-zero exit code when stopping an already-stopped container; Docker returns 0
- With `set -e` active, this caused the script to abort before the `rm` command ran
- Added `|| true` to `stop` and `rm` calls in `stop_workers` and `stop_agent`