### PR TITLE
Add option to use extra_hosts and add hostAlias 

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -181,6 +181,17 @@ helm upgrade --install hd-agent \
 
 > **Note:** JVM memory values support standard Java memory units (e.g., 800m, 1g, 2G). Ensure the JVM memory settings are appropriate for your container memory limits and that both values match for optimal performance.
 
+## Pinning hostnames (config.extra_hosts)
+
+`config.extra_hosts` pins hostnames to specific IPs on the agent pod (rendered as `hostAliases`). The format is a semicolon-separated list of `host:ip` pairs:
+
+```yaml
+config:
+  extra_hosts: "ldp.orchestrator.fivetran.com:35.188.225.82;api.fivetran.com:35.236.237.87"
+```
+
+> **Note:** The above is purely an example. Only set `extra_hosts` if requested by Fivetran Support, or if a DNS override is required.
+
 ## PodDisruptionBudgets
 
 By default, the chart creates PodDisruptionBudgets (PDBs) for both the agent (`hd-agent-pdb`) and the data processing jobs (`hd-job-pdb`), each with `minAvailable: 1`. If your environment does not require PDBs, you can disable them:

--- a/agent/templates/deployment.yaml
+++ b/agent/templates/deployment.yaml
@@ -42,6 +42,24 @@ spec:
         {{- end }}
       {{- end }}
       restartPolicy: Always
+      {{- if .Values.config.extra_hosts }}
+      hostAliases:
+        {{- range splitList ";" .Values.config.extra_hosts }}
+        {{- $entry := trim . }}
+        {{- if $entry }}
+        {{- $parts := splitList ":" $entry }}
+        {{- if eq (len $parts) 2 }}
+        {{- $host := trim (index $parts 0) }}
+        {{- $ip := trim (index $parts 1) }}
+        {{- if and $host $ip }}
+        - ip: {{ $ip | quote }}
+          hostnames:
+            - {{ $host | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.config.custom_dns }}
       dnsConfig:
         nameservers:

--- a/agent/values.schema.json
+++ b/agent/values.schema.json
@@ -29,6 +29,10 @@
           "type": "string",
           "description": "Authentication token secret name to be reference for the agent"
         },
+        "extra_hosts": {
+          "type": "string",
+          "description": "Optional semicolon-separated host:ip overrides; renders pod hostAliases (IPv4)."
+        },
         "kubernetes_affinity": {
           "type": "array",
           "items": {


### PR DESCRIPTION
* Add support for using config.extra_hosts to add custom hostAlias entries to deployment.