### PR TITLE
feature(hybrid_deployment): Changing minAvailable to maxUnavailable

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -194,7 +194,7 @@ config:
 
 ## PodDisruptionBudgets
 
-By default, the chart creates PodDisruptionBudgets (PDBs) for both the agent (`hd-agent-pdb`) and the data processing jobs (`hd-job-pdb`), each with `minAvailable: 1`. If your environment does not require PDBs, you can disable them:
+By default, the chart creates PodDisruptionBudgets (PDBs) for both the agent (`hd-agent-pdb`) and the data processing jobs (`hd-job-pdb`), each with `maxUnavailable: 1`. If your environment does not require PDBs, you can disable them:
 
 ```yaml
 pdb:

--- a/agent/templates/pdb.yaml
+++ b/agent/templates/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: hd-agent-pdb
     {{- include "hd.labels" . | nindent 4 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: hd-agent
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/name: hd-job-pdb
     {{- include "hd.labels" . | nindent 4 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/part-of: hybrid-deployment


### PR DESCRIPTION
To better facilitate draining of kubernetes cluster in environments that utilize autoscalers like Karpenter, we want to allow the agent node to be drained during scaling operations so it doesn't interfere with a customers existing cluster setup. Changing the PDB to use `maxUnavailable` from `minAvailable` will allow the node to drain properly while ensuring an agent is always running